### PR TITLE
Tweaks to make Sniffer global analysis work

### DIFF
--- a/pear_backend/src/refiner/refiner.rs
+++ b/pear_backend/src/refiner/refiner.rs
@@ -57,7 +57,7 @@ impl<'tcx> RefinedNode<'tcx> {
     }
 }
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
 pub struct TaintedNode<'tcx> {
     node: Instance<'tcx>,
     span: Span,
@@ -110,6 +110,10 @@ impl<'tcx> RefinedUsageGraph<'tcx> {
             forward_edges: FxHashMap::default(),
             backward_edges: FxHashMap::default(),
         }
+    }
+
+    pub fn root(&self) -> Instance<'tcx> {
+        self.root
     }
 
     fn add_edge(&mut self, from: &Instance<'tcx>, to: &RefinedNode<'tcx>) {


### PR DESCRIPTION
derive Debug for TaintedNode and add root() method to RefinedUsageGraph