### PR TITLE
Fix improper "important" taint propagation bug

### DIFF
--- a/pear_frontend/src/analysis/scrutinizer/analyzer/mod.rs
+++ b/pear_frontend/src/analysis/scrutinizer/analyzer/mod.rs
@@ -2,4 +2,7 @@ mod analyzer;
 mod heuristics;
 mod result;
 
-pub use {analyzer::ScrutinizerAnalysis, result::ImpurityReason, result::PurityAnalysisResult};
+pub use {
+    analyzer::ImportantArgs, analyzer::ScrutinizerAnalysis, result::ImpurityReason,
+    result::PurityAnalysisResult,
+};

--- a/pear_frontend/src/analysis/scrutinizer/scrutinizer_global.rs
+++ b/pear_frontend/src/analysis/scrutinizer/scrutinizer_global.rs
@@ -12,7 +12,7 @@ use pear_backend::{collect_from, refine_from, GlobalAnalysis};
 use serde::{Deserialize, Serialize};
 
 use crate::analysis::scrutinizer::{
-    analyzer::{ImpurityReason, PurityAnalysisResult, ScrutinizerAnalysis},
+    analyzer::{ImportantArgs, ImpurityReason, PurityAnalysisResult, ScrutinizerAnalysis},
     scrutinizer_local::substituted_mir,
     selector::{select_functions, select_pprs},
     utils::instance_sig,
@@ -154,10 +154,13 @@ impl<'tcx> GlobalAnalysis<'tcx> for ScrutinizerGlobalAnalysis {
                     } else {
                         config.important_args.as_ref().unwrap().to_owned()
                     };
-                    important_args
-                        .into_iter()
-                        .map(|arg_num| Local::from_usize(arg_num))
-                        .collect()
+
+                    ImportantArgs::Args(
+                        important_args
+                            .into_iter()
+                            .map(|arg_num| Local::from_usize(arg_num))
+                            .collect(),
+                    )
                 };
 
                 let allowlist = config

--- a/tests/src/scrutinizer/tests/leaky.rs
+++ b/tests/src/scrutinizer/tests/leaky.rs
@@ -71,3 +71,29 @@ mod adversarial {
         *sink_mut[0] = value;
     }
 }
+
+mod leaky_no_args {
+    #[pear::scrutinizer_impure]
+    fn leak_conditional(s: String) {
+        if s.len() > 0 {
+            print_something();
+        }
+    }
+
+    #[pear::scrutinizer_impure]
+    fn leak_conditional_some_args(s: String) {
+        if s.len() > 0 {
+            print_something_one_arg(42);
+        }
+    }
+
+    #[pear::scrutinizer_pure]
+    fn print_something() {
+        println!("foo");
+    }
+
+    #[pear::scrutinizer_pure]
+    fn print_something_one_arg(a: u32) {
+        println!("foo");
+    }
+}


### PR DESCRIPTION
The original Scrutinizer has a bug, where the following function would be falsely categorized as "non-leaking":

```rs
// Categorized as "non-leaking" while it leaks via control flow.
#[pear::scrutinizer_impure] 
fn leak_conditional(s: String) {
    if s.len() > 0 {
        print_something();
    }
}

fn print_something() {
    println!("foo");
}
```

The cause is in the Flowistry-guided optimization of Scrutinizer: it only propagates the "important" taint to functions through its arguments, while control-flow dependencies could implicitly affect its leakage status. 

Simplifying the optimization to only work on the top-level function solves the issue without loss in precision on our tests. Modified Scrutinizer from this branch also ran on Websubmit and successfully verified all VRs, with the following lines added to the allowlist:

```
# Abort.
'core\[\w*\]::intrinsics::\{extern#0\}::abort',

# Atomics.
'core\[\w*\]::intrinsics::\{extern#0\}::atomic',

# Caller location.
'core\[\w*\]::intrinsics::\{extern#0\}::caller_location',

# Panicking.
'std\[\w*\]::panicking::begin_panic',

# Alloc error handler.
'alloc\[\w*\]::alloc::\{extern#1\}::__rust_alloc_error_handler',

# Formatting.
'core\[\w*\]::fmt::rt::\{impl#1\}::new',
```

All of the additions are consistent with the categories for the original Scrutinizer. Some of them are needed because of the compiler version update triggered by PEAR.

The fix is coarse-grained --- it conservatively assumes that if there is a flow to the function, it is implicit. I think it is possible to make it more precise by checking whether the function _execution_ is affected by any of the important arguments.